### PR TITLE
Add in port forwarding to get MSGamepass to work

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,10 +12,21 @@ pub struct RunRequest {
 }
 
 #[derive(Serialize)]
+pub struct ProcessRunningResponse {
+    process_is_running: bool,
+}
+#[derive(Serialize)]
 pub struct RunResponse {
     pub success: bool,
     pub pid: Option<u32>,
 }
+
+#[derive(Serialize, Clone)]
+pub struct PortForward {
+    pub port: u16,
+    pub address: String,
+}
+
 
 pub fn allowed_executables() -> HashSet<String> {
     let mut set = HashSet::new();

--- a/src/handlers/port_forward.rs
+++ b/src/handlers/port_forward.rs
@@ -1,0 +1,79 @@
+use std::{process::Command, sync::Arc};
+
+use regex::Regex;
+
+use crate::constants::PortForward;
+
+/// Forward a port using netsh portproxy
+pub fn forward_port(port: u16) -> Arc<PortForward> {
+    clear_endpoints(port);
+    let endpoint = get_endpoint();
+    let target_address = Arc::new(PortForward { port, address: format!("127.0.0.{endpoint}") });
+
+    let output = Command::new("netsh")
+        .args(&[
+            "interface", "portproxy", "add", "v4tov4",
+            &format!("listenaddress={}", &target_address.address), 
+            "listenport=80", "connectaddress=127.0.0.1", 
+            &format!("connectport={}", port)
+        ])
+        .output()
+        .expect("failed to retrieve portproxy");
+     let _outputStr = String::from_utf8_lossy(&output.stdout);
+     if output.status.success() {
+        return target_address;
+    }
+    eprintln!("Failed to forward port {}: {}", port, String::from_utf8_lossy(&output.stderr));
+    return Arc::new(PortForward { port, address: String::new() }) // Return    
+}
+
+pub fn remove_portforward(target_address: String) {
+    let _output = Command::new("netsh")
+        .args(&["interface", "portproxy", "delete", "v4tov4",
+        &format!("listenaddress={}", &target_address), "listenport=80"
+        ])
+        .output()
+        .expect("failed to retrieve portproxy");
+}
+
+pub fn clear_endpoints(targetPort:u16)
+{
+    let output = Command::new("netsh")
+        .args(&["interface", "portproxy","show","v4tov4"])
+        .output()
+        .expect("failed to retrieve portproxy");
+    if output.status.success(){
+        let outputStr = String::from_utf8_lossy(&output.stdout);
+        let existing_forwards = outputStr.lines();
+        if existing_forwards.count() > 0 {
+            let re = Regex::new (format!(r".*{}$", targetPort).as_str()).unwrap();
+            let decimal_lines: Vec<&str> = outputStr
+                .lines()
+                .filter(|line| re.is_match (line))
+                .collect();
+
+            for line in decimal_lines {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                remove_portforward(parts[0].to_string());
+            }
+        }
+    }
+}
+// Cycle through the endpoints until we find a match, starting with 127.0.0.80
+pub fn get_endpoint() -> u16{    
+    let output = Command::new("netsh")
+        .args(&["interface", "portproxy","show","v4tov4"])
+        .output()
+        .expect("failed to retrieve portproxy");
+    if output.status.success(){
+        let outputStr = String::from_utf8_lossy(&output.stdout);
+        let mut targetAddr = 80;
+        let mut re = Regex::new (format!("127.0.0.{}", targetAddr).as_str()).unwrap();
+        while re.is_match(&outputStr) {
+            targetAddr += 1;
+            re = Regex::new (format!("127.0.0.{}", targetAddr).as_str()).unwrap();
+        }
+        return targetAddr;
+    }
+    return 80;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,9 @@
 
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use lazy_static::lazy_static;
-use serde::Serialize;
 use serde_json::from_reader;
 use std::{
-    collections::HashSet, env, ffi::OsStr, fs::File, io::Result as IoResult,
-    os::windows::ffi::OsStrExt, ptr, sync::Mutex, thread, time::Duration,
+    collections::HashSet, env, ffi::OsStr, fs::File, io::Result as IoResult, os::windows::ffi::OsStrExt,  ptr, sync::{Arc, Mutex}, thread, time::Duration
 };
 use tiny_http::{Server, StatusCode};
 use winapi::{
@@ -26,6 +24,7 @@ mod handlers {
     pub mod run;
     pub mod shutdown;
     pub mod stop_process;
+    pub mod port_forward;
 }
 
 use constants::{Config, CONFIG_NAME, DEFAULT_PORT, MUTEX_NAME};
@@ -36,12 +35,10 @@ use handlers::{
     stop_process::handle_stop_process_request,
 };
 use processes::{is_darktide_running, is_process_running};
-use utilities::empty_response_with_status;
+use utilities::{empty_response_with_status};
 
-#[derive(Serialize)]
-struct ProcessRunningResponse {
-    process_is_running: bool,
-}
+use crate::handlers::port_forward::{forward_port, remove_portforward};
+
 
 lazy_static! {
     static ref CREATED_PIDS: Mutex<HashSet<u32>> = Mutex::new(HashSet::new());
@@ -87,9 +84,28 @@ fn main() -> IoResult<()> {
         Receiver<tiny_http::Request>,
     ) = unbounded();
 
-    thread::spawn(|| loop {
+    let mut forwarded: Arc<bool> = Arc::new(false);
+    
+    let target_address: Arc<constants::PortForward> = forward_port(port);
+    
+    if !target_address.address.is_empty() {
+        forwarded = Arc::new(true);
+        println!("Port forwarding enabled for port {}", port);
+    } else {
+        eprintln!("Failed to forward port {}", port);
+    }
+
+    let target_address_for_shutdown = Arc::clone(&target_address);
+    let target_address_for_monitor = Arc::clone(&target_address);
+    let forwarded_for_monitor = Arc::clone(&forwarded);
+    let forwarded_for_shutdown = Arc::clone(&forwarded);
+
+    thread::spawn(move || loop {
         if !is_darktide_running() {
             println!("Darktide.exe is not running. Shutting down.");
+            if *forwarded_for_monitor {
+                remove_portforward(target_address_for_monitor.address.clone());
+            }
             std::process::exit(1);
         }
         thread::sleep(Duration::from_secs(1));
@@ -103,13 +119,14 @@ fn main() -> IoResult<()> {
                 .respond(response.unwrap_or_else(|_| empty_response_with_status(StatusCode(400))));
         }
     });
-
+    
     // Main thread for other requests
+    let target_address = target_address_for_shutdown;
     thread::spawn(move || {
         for mut request in server.incoming_requests() {
             let url = request.url().to_string();
-            let method = request.method().to_string();
-
+            let method = request.method().to_string();            
+            let target_address = Arc::clone(&target_address);
             if method == "GET" {
                 if url.starts_with("/dds_image") {
                     let response = handle_dds_image_request(&request)
@@ -138,6 +155,9 @@ fn main() -> IoResult<()> {
                 }
 
                 if url == "/shutdown" {
+                    if *forwarded_for_shutdown {
+                        remove_portforward(target_address.address.clone());
+                    }
                     handle_shutdown_request();
                 }
 
@@ -165,3 +185,5 @@ fn main() -> IoResult<()> {
         thread::sleep(Duration::from_secs(60));
     }
 }
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,12 +121,11 @@ fn main() -> IoResult<()> {
     });
     
     // Main thread for other requests
-    let target_address = target_address_for_shutdown;
+    
     thread::spawn(move || {
         for mut request in server.incoming_requests() {
             let url = request.url().to_string();
-            let method = request.method().to_string();            
-            let target_address = Arc::clone(&target_address);
+            let method = request.method().to_string();                        
             if method == "GET" {
                 if url.starts_with("/dds_image") {
                     let response = handle_dds_image_request(&request)
@@ -156,7 +155,7 @@ fn main() -> IoResult<()> {
 
                 if url == "/shutdown" {
                     if *forwarded_for_shutdown {
-                        remove_portforward(target_address.address.clone());
+                        remove_portforward(target_address_for_shutdown.address.clone());
                     }
                     handle_shutdown_request();
                 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::io::Cursor;
+use std::{io::Cursor};
 use tiny_http::{Header, Response, StatusCode};
 
 /// Splits a string into space-separated segments, ignoring spaces in quoted substrings


### PR DESCRIPTION
Ok, don't actually merge this, but the work is done to use netsh to create a portforward, 

MS Gamepass version doesn't like using ports when requesting uris, so this creates a portforward for 127.0.0.80:80 to 127.0.0.1:41012 so we can just use http://127.0.0.80/ 
it also cleans up prior port forwards and tries to clean up the portforward on close

Issues are that you need elevated privileges to execute the port forward, and while you can set the exe to launch as admin, you get the UAC prompt to do so every single time you reload mods, which can cause a deadlock if you don't realise it's asking in the background (also, very annoying). It may be by passable if we sign the exe maybe, but I'm unsure.

Anyway, here's some work. I have a combo set of batch files to create/remove the portforwards, and can walk people through the process, but no easy drop in solution